### PR TITLE
Ignore node_modules and Playwright output dirs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,10 @@ desktop.ini
 
 # Old files
 conjugate_study_app.html
+
+# Node / Playwright
+node_modules/
+package-lock.json
+test-results/
+playwright-report/
+


### PR DESCRIPTION
## Summary

The repo has a `package.json` with Playwright as a devDependency, but `.gitignore` never covered the install output. Anyone running `npm install` (e.g. to run the test suite) ends up with `node_modules/` and `package-lock.json` as untracked noise. Adding the standard Node/Playwright entries.

## Test plan

- [ ] `npm install` followed by `git status` shows a clean working tree.
- [ ] `npx playwright test` does not flood the tree with tracked artifacts.

https://claude.ai/code/session_01BoYpAjhx865wfSwt5m6FZ4

---
_Generated by [Claude Code](https://claude.ai/code/session_01BoYpAjhx865wfSwt5m6FZ4)_