### PR TITLE
Error reporting + auto-post feedback as GitHub issues via Cloudflare Worker

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,10 @@ desktop.ini
 
 # Old files
 conjugate_study_app.html
+
+# Node / Playwright
+node_modules/
+package-lock.json
+test-results/
+playwright-report/
+

--- a/index.html
+++ b/index.html
@@ -868,6 +868,7 @@ button.quiz-opt.opt-correct { animation: correctPulse 0.6s ease; }
     <span id="syncUserBar" class="sync-user-bar" style="display:none"></span>
     <span id="headerUserEmail" style="display:none;font-size:0.75rem;color:var(--text-muted);max-width:140px;overflow:hidden;text-overflow:ellipsis;white-space:nowrap"></span>
     <button class="icon-btn" id="headerSignOutBtn" title="Sign out" aria-label="Sign out" style="display:none;font-size:0.85rem" onclick="LAB.signOutLocal()">🚪</button>
+    <button class="icon-btn" id="bugReportBtn" title="Report a problem" aria-label="Report a problem" onclick="BUG.promptAndReport()">&#x1F41B;</button>
     <button class="icon-btn" id="syncBtn" title="Sync across devices" aria-label="Sync across devices">&#x1F504;</button>
     <button class="icon-btn" id="darkModeBtn" title="Toggle dark mode" aria-label="Toggle dark mode">&#x1F319;</button>
   </div>
@@ -969,22 +970,113 @@ button.quiz-opt.opt-correct { animation: correctPulse 0.6s ease; }
 
 <script>
 // =======================================
+// BUG REPORTING — pre-fills a GitHub issue
+// =======================================
+var BUG = {
+  ISSUE_BASE: 'https://github.com/Satuno86/conjugate-study-hub/issues/new',
+
+  collectContext: function() {
+    var email = '';
+    try { email = localStorage.getItem('conjugate_user_email') || ''; } catch(e) {}
+    var errors = [];
+    try { errors = JSON.parse(localStorage.getItem('_errorLog') || '[]'); } catch(e) {}
+    return {
+      timestamp: new Date().toISOString(),
+      url: location.href,
+      email: email,
+      userAgent: navigator.userAgent,
+      recentErrors: errors.slice(-5)
+    };
+  },
+
+  buildIssueURL: function(title, userText, autoDetail, labels) {
+    var ctx = this.collectContext();
+    var lines = [];
+    if (userText) { lines.push(userText, '', '---', ''); }
+    if (autoDetail) { lines.push(autoDetail, ''); }
+    lines.push('**Diagnostic context** (auto-attached):');
+    lines.push('- Time: ' + ctx.timestamp);
+    lines.push('- URL: ' + ctx.url);
+    if (ctx.email) lines.push('- User: ' + ctx.email);
+    lines.push('- User agent: ' + ctx.userAgent);
+    if (ctx.recentErrors.length) {
+      lines.push('', '**Recent JS errors (last ' + ctx.recentErrors.length + '):**', '```');
+      ctx.recentErrors.forEach(function(e) {
+        var when = e.ts ? new Date(e.ts).toISOString() : '?';
+        lines.push(when + ' — ' + (e.msg || '?') + ' @ ' + (e.src || '?') + ':' + (e.line || '?') + ':' + (e.col || '?'));
+      });
+      lines.push('```');
+    }
+    var body = lines.join('\n');
+    return this.ISSUE_BASE +
+      '?title=' + encodeURIComponent(title) +
+      '&body=' + encodeURIComponent(body) +
+      '&labels=' + encodeURIComponent(labels || 'bug,user-report');
+  },
+
+  promptAndReport: function() {
+    var msg = window.prompt('Briefly describe what went wrong (leave blank to just send diagnostics):');
+    if (msg === null) return;
+    var title = (msg && msg.trim()) ? '[Bug] ' + msg.trim().slice(0, 80) : '[Bug] Report from user';
+    var url = this.buildIssueURL(title, msg);
+    var opened = window.open(url, '_blank', 'noopener');
+    if (!opened) showToast('Pop-up blocked — please allow pop-ups to file a report.');
+  },
+
+  reportError: function(entry) {
+    var summary = entry && entry.msg ? entry.msg : 'Unknown error';
+    var title = '[Auto] ' + String(summary).slice(0, 80);
+    var detail = '**Auto-captured error:**\n```\n' + summary +
+      '\n  at ' + (entry.src || '?') + ':' + (entry.line || '?') + ':' + (entry.col || '?') + '\n```';
+    var url = this.buildIssueURL(title, '', detail, 'bug,auto-captured');
+    var opened = window.open(url, '_blank', 'noopener');
+    if (!opened) showToast('Pop-up blocked — please allow pop-ups to file a report.');
+  }
+};
+
+// Persistent error banner (won't auto-dismiss; offers a Report button)
+function showErrorBanner(entry) {
+  try {
+    var existing = document.getElementById('errorBanner');
+    if (existing) existing.remove();
+    var bar = document.createElement('div');
+    bar.id = 'errorBanner';
+    bar.style.cssText = 'position:fixed;bottom:1rem;left:50%;transform:translateX(-50%);max-width:min(560px,92vw);background:#b00020;color:#fff;padding:0.85rem 1rem;border-radius:10px;box-shadow:0 6px 20px rgba(0,0,0,0.28);z-index:99998;display:flex;gap:0.6rem;align-items:center;font-size:0.9rem;line-height:1.4;font-family:inherit';
+    var msgText = (typeof esc === 'function') ? esc(entry.msg || 'Unknown error') : String(entry.msg || 'Unknown error');
+    bar.innerHTML =
+      '<span style="flex:1;min-width:0;overflow:hidden;text-overflow:ellipsis">⚠️ Something went wrong: <code style="background:rgba(255,255,255,0.18);padding:0.1rem 0.35rem;border-radius:4px;font-size:0.8rem">' + msgText + '</code></span>' +
+      '<button id="errorBannerReport" style="background:#fff;color:#b00020;border:none;padding:0.4rem 0.75rem;border-radius:6px;cursor:pointer;font-weight:600;font-size:0.85rem;white-space:nowrap">Report</button>' +
+      '<button id="errorBannerDismiss" style="background:transparent;color:#fff;border:1px solid rgba(255,255,255,0.4);padding:0.35rem 0.6rem;border-radius:6px;cursor:pointer;font-size:0.85rem">Dismiss</button>';
+    document.body.appendChild(bar);
+    document.getElementById('errorBannerReport').addEventListener('click', function() { BUG.reportError(entry); });
+    document.getElementById('errorBannerDismiss').addEventListener('click', function() { bar.remove(); });
+  } catch(e) {
+    if (typeof showToast === 'function') showToast('Error: ' + (entry.msg || 'Unknown error'));
+  }
+}
+
+// =======================================
 // GLOBAL ERROR HANDLER
 // =======================================
 window.onerror = function(msg, src, line, col, err) {
   try {
-    var label = 'Error: ' + (msg || 'Unknown error');
-    if (typeof showToast === 'function') showToast(label);
+    var entry = { msg: msg, src: src, line: line, col: col, ts: Date.now() };
     var log = JSON.parse(localStorage.getItem('_errorLog') || '[]');
-    log.push({ msg: msg, src: src, line: line, col: col, ts: Date.now() });
+    log.push(entry);
     if (log.length > 50) log = log.slice(-50);
     localStorage.setItem('_errorLog', JSON.stringify(log));
+    showErrorBanner(entry);
   } catch(e) {}
 };
 window.addEventListener('unhandledrejection', function(e) {
   try {
-    var label = 'Async error: ' + (e.reason && e.reason.message ? e.reason.message : 'Unknown');
-    if (typeof showToast === 'function') showToast(label);
+    var reasonMsg = e.reason && e.reason.message ? e.reason.message : 'Unknown async error';
+    var entry = { msg: reasonMsg, src: 'unhandledrejection', line: 0, col: 0, ts: Date.now() };
+    var log = JSON.parse(localStorage.getItem('_errorLog') || '[]');
+    log.push(entry);
+    if (log.length > 50) log = log.slice(-50);
+    localStorage.setItem('_errorLog', JSON.stringify(log));
+    showErrorBanner(entry);
   } catch(ex) {}
 });
 
@@ -3154,7 +3246,7 @@ var SV = {
     log.push(entry);
     writeJSON(this.feedbackKey, log);
 
-    // Try to open a pre-filled GitHub issue
+    // Open a pre-filled GitHub issue with diagnostic context auto-attached
     var topicLabels = {
       general: 'General Feedback',
       confusing: 'Confusing/Wrong Question',
@@ -3163,16 +3255,10 @@ var SV = {
       bug: 'Bug Report',
       love: 'Positive Feedback'
     };
-    var title = encodeURIComponent('[Feedback] ' + topicLabels[topic]);
-    var body = encodeURIComponent(
-      '**From:** Anna\n' +
-      '**Category:** ' + topicLabels[topic] + '\n' +
-      '**Date:** ' + new Date().toLocaleDateString() + '\n\n' +
-      '---\n\n' +
-      message + '\n\n' +
-      '---\n_Submitted from Conjugate Study Hub_'
-    );
-    var issueUrl = 'https://github.com/Satuno86/conjugate-study-hub/issues/new?title=' + title + '&body=' + body + '&labels=feedback';
+    var labelTag = (topic === 'bug' || topic === 'confusing') ? 'bug,feedback' : 'feedback';
+    var titleStr = '[Feedback] ' + topicLabels[topic] + ': ' + message.slice(0, 60);
+    var userBody = '**Category:** ' + topicLabels[topic] + '\n\n' + message;
+    var issueUrl = BUG.buildIssueURL(titleStr, userBody, null, labelTag);
 
     status.style.display = 'block';
     status.innerHTML =

--- a/index.html
+++ b/index.html
@@ -1061,14 +1061,35 @@ var BUG = {
       });
   },
 
+  // Translate a reportIssue result into a user-facing toast. Both r.error and
+  // r.popupBlocked can be true at the same time (auto-post failed AND the
+  // fallback popup was blocked by the browser) — surface both, and log the URL
+  // so the user has a path forward.
+  _toastForResult: function(r, postedMsg) {
+    if (r.posted) { showToast(postedMsg); return; }
+    if (r.error && r.popupBlocked) {
+      try { console.warn('[BUG] auto-post failed AND popup blocked. File manually:', r.url); } catch(e) {}
+      showToast('Auto-post failed (' + r.error + ') and the GitHub tab was blocked — check the console for the URL or allow pop-ups and retry.');
+      return;
+    }
+    if (r.popupBlocked) {
+      try { console.warn('[BUG] popup blocked. File manually:', r.url); } catch(e) {}
+      showToast('Pop-up blocked — allow pop-ups to file a report (URL logged to console).');
+      return;
+    }
+    if (r.error) {
+      showToast('Auto-post failed (' + r.error + ') — opened GitHub to file manually.');
+      return;
+    }
+  },
+
   promptAndReport: function() {
     var msg = window.prompt('Briefly describe what went wrong (leave blank to just send diagnostics):');
     if (msg === null) return;
     var title = (msg && msg.trim()) ? '[Bug] ' + msg.trim().slice(0, 80) : '[Bug] Report from user';
+    var self = this;
     this.reportIssue(title, msg, null, ['bug', 'user-report']).then(function(r) {
-      if (r.posted) showToast('Reported! Issue #' + r.number + ' filed.');
-      else if (r.error) showToast('Auto-post failed (' + r.error + ') — opened GitHub to file manually.');
-      else if (r.popupBlocked) showToast('Pop-up blocked — please allow pop-ups to file a report.');
+      self._toastForResult(r, 'Reported! Issue #' + r.number + ' filed.');
     });
   },
 
@@ -1077,10 +1098,9 @@ var BUG = {
     var title = '[Auto] ' + String(summary).slice(0, 80);
     var detail = '**Auto-captured error:**\n```\n' + summary +
       '\n  at ' + (entry.src || '?') + ':' + (entry.line || '?') + ':' + (entry.col || '?') + '\n```';
+    var self = this;
     this.reportIssue(title, '', detail, ['bug', 'auto-captured']).then(function(r) {
-      if (r.posted) showToast('Error reported as issue #' + r.number + '.');
-      else if (r.error) showToast('Auto-post failed (' + r.error + ') — opened GitHub to file manually.');
-      else if (r.popupBlocked) showToast('Pop-up blocked — please allow pop-ups to file a report.');
+      self._toastForResult(r, 'Error reported as issue #' + r.number + '.');
     });
   }
 };
@@ -3323,14 +3343,21 @@ var SV = {
               'style="color:var(--accent);text-decoration:underline">issue #' + r.number + '</a>.' +
           '</div>';
       } else {
-        var note = r.error
-          ? 'Auto-post failed (' + esc(r.error) + ') — opened GitHub so you can post manually.'
-          : 'Saved locally. We opened a pre-filled GitHub page so Auston can see it.';
+        var note;
+        if (r.error && r.popupBlocked) {
+          note = 'Auto-post failed (' + esc(r.error) + ') and the GitHub tab was blocked. Click the link below to file it manually.';
+        } else if (r.error) {
+          note = 'Auto-post failed (' + esc(r.error) + ') — opened GitHub so you can post manually.';
+        } else if (r.popupBlocked) {
+          note = 'Saved locally. The GitHub tab was blocked — click the link below to file it.';
+        } else {
+          note = 'Saved locally. We opened a pre-filled GitHub page so Auston can see it.';
+        }
         status.innerHTML =
           '<div class="fb-correct" style="line-height:1.5">' +
             '&#x2705; ' + note + '<br>' +
             '<a href="' + r.url + '" target="_blank" rel="noopener" ' +
-              'style="color:var(--accent);text-decoration:underline;font-size:0.9rem">Open the GitHub page again</a>' +
+              'style="color:var(--accent);text-decoration:underline;font-size:0.9rem">Open the GitHub page</a>' +
           '</div>';
       }
       self.renderHistory();

--- a/index.html
+++ b/index.html
@@ -974,6 +974,9 @@ button.quiz-opt.opt-correct { animation: correctPulse 0.6s ease; }
 // =======================================
 var BUG = {
   ISSUE_BASE: 'https://github.com/Satuno86/conjugate-study-hub/issues/new',
+  // Cloudflare Worker URL that auto-posts issues using a server-side token.
+  // Empty = fall back to opening a pre-filled GitHub new-issue page in a new tab.
+  FEEDBACK_ENDPOINT: '',
 
   collectContext: function() {
     var email = '';
@@ -989,7 +992,7 @@ var BUG = {
     };
   },
 
-  buildIssueURL: function(title, userText, autoDetail, labels) {
+  _composeBody: function(userText, autoDetail) {
     var ctx = this.collectContext();
     var lines = [];
     if (userText) { lines.push(userText, '', '---', ''); }
@@ -1007,20 +1010,66 @@ var BUG = {
       });
       lines.push('```');
     }
-    var body = lines.join('\n');
+    return lines.join('\n');
+  },
+
+  _normalizeLabels: function(labels) {
+    if (Array.isArray(labels)) return labels;
+    if (typeof labels === 'string' && labels) return labels.split(',').map(function(s){return s.trim();}).filter(Boolean);
+    return ['bug', 'user-report'];
+  },
+
+  buildIssueURL: function(title, userText, autoDetail, labels) {
+    var body = this._composeBody(userText, autoDetail);
+    var labelStr = this._normalizeLabels(labels).join(',');
     return this.ISSUE_BASE +
       '?title=' + encodeURIComponent(title) +
       '&body=' + encodeURIComponent(body) +
-      '&labels=' + encodeURIComponent(labels || 'bug,user-report');
+      '&labels=' + encodeURIComponent(labelStr);
+  },
+
+  postIssue: function(title, body, labels) {
+    if (!this.FEEDBACK_ENDPOINT) return Promise.reject(new Error('no_endpoint'));
+    return fetch(this.FEEDBACK_ENDPOINT, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ title: title, body: body, labels: labels })
+    }).then(function(res) {
+      return res.json().then(function(j) {
+        if (!res.ok) throw new Error(j.error || ('HTTP ' + res.status));
+        return j;
+      });
+    });
+  },
+
+  // Tries to auto-post via the worker; falls back to opening the pre-filled
+  // GitHub new-issue page in a new tab. Always resolves; never throws.
+  // Returns { posted: bool, url: string, error?: string }.
+  reportIssue: function(title, userText, autoDetail, labels) {
+    var body = this._composeBody(userText, autoDetail);
+    var normLabels = this._normalizeLabels(labels);
+    var fallbackUrl = this.buildIssueURL(title, userText, autoDetail, normLabels);
+    if (!this.FEEDBACK_ENDPOINT) {
+      var opened = window.open(fallbackUrl, '_blank', 'noopener');
+      return Promise.resolve({ posted: false, url: fallbackUrl, fallback: 'no_endpoint', popupBlocked: !opened });
+    }
+    return this.postIssue(title, body, normLabels)
+      .then(function(j) { return { posted: true, url: j.url, number: j.number }; })
+      .catch(function(err) {
+        var opened2 = window.open(fallbackUrl, '_blank', 'noopener');
+        return { posted: false, url: fallbackUrl, error: err.message, popupBlocked: !opened2 };
+      });
   },
 
   promptAndReport: function() {
     var msg = window.prompt('Briefly describe what went wrong (leave blank to just send diagnostics):');
     if (msg === null) return;
     var title = (msg && msg.trim()) ? '[Bug] ' + msg.trim().slice(0, 80) : '[Bug] Report from user';
-    var url = this.buildIssueURL(title, msg);
-    var opened = window.open(url, '_blank', 'noopener');
-    if (!opened) showToast('Pop-up blocked — please allow pop-ups to file a report.');
+    this.reportIssue(title, msg, null, ['bug', 'user-report']).then(function(r) {
+      if (r.posted) showToast('Reported! Issue #' + r.number + ' filed.');
+      else if (r.error) showToast('Auto-post failed (' + r.error + ') — opened GitHub to file manually.');
+      else if (r.popupBlocked) showToast('Pop-up blocked — please allow pop-ups to file a report.');
+    });
   },
 
   reportError: function(entry) {
@@ -1028,9 +1077,11 @@ var BUG = {
     var title = '[Auto] ' + String(summary).slice(0, 80);
     var detail = '**Auto-captured error:**\n```\n' + summary +
       '\n  at ' + (entry.src || '?') + ':' + (entry.line || '?') + ':' + (entry.col || '?') + '\n```';
-    var url = this.buildIssueURL(title, '', detail, 'bug,auto-captured');
-    var opened = window.open(url, '_blank', 'noopener');
-    if (!opened) showToast('Pop-up blocked — please allow pop-ups to file a report.');
+    this.reportIssue(title, '', detail, ['bug', 'auto-captured']).then(function(r) {
+      if (r.posted) showToast('Error reported as issue #' + r.number + '.');
+      else if (r.error) showToast('Auto-post failed (' + r.error + ') — opened GitHub to file manually.');
+      else if (r.popupBlocked) showToast('Pop-up blocked — please allow pop-ups to file a report.');
+    });
   }
 };
 
@@ -3246,7 +3297,7 @@ var SV = {
     log.push(entry);
     writeJSON(this.feedbackKey, log);
 
-    // Open a pre-filled GitHub issue with diagnostic context auto-attached
+    // Auto-post to GitHub if the worker is configured, otherwise pre-fill a new-issue tab.
     var topicLabels = {
       general: 'General Feedback',
       confusing: 'Confusing/Wrong Question',
@@ -3255,23 +3306,35 @@ var SV = {
       bug: 'Bug Report',
       love: 'Positive Feedback'
     };
-    var labelTag = (topic === 'bug' || topic === 'confusing') ? 'bug,feedback' : 'feedback';
+    var labelArr = (topic === 'bug' || topic === 'confusing') ? ['bug','feedback'] : ['feedback'];
     var titleStr = '[Feedback] ' + topicLabels[topic] + ': ' + message.slice(0, 60);
     var userBody = '**Category:** ' + topicLabels[topic] + '\n\n' + message;
-    var issueUrl = BUG.buildIssueURL(titleStr, userBody, null, labelTag);
 
     status.style.display = 'block';
-    status.innerHTML =
-      '<div class="fb-correct" style="line-height:1.5">' +
-        '&#x2705; Feedback saved! Thank you, Anna!<br>' +
-        '<a href="' + issueUrl + '" target="_blank" rel="noopener" ' +
-          'style="color:var(--accent);text-decoration:underline;font-size:0.9rem">' +
-          'Click here to also post it on GitHub for Auston to see' +
-        '</a>' +
-      '</div>';
-
+    status.innerHTML = '<div class="fb-correct" style="line-height:1.5">Sending to Auston…</div>';
     document.getElementById('svMessage').value = '';
-    this.renderHistory();
+    var self = this;
+    BUG.reportIssue(titleStr, userBody, null, labelArr).then(function(r) {
+      if (r.posted) {
+        status.innerHTML =
+          '<div class="fb-correct" style="line-height:1.5">' +
+            '&#x2705; Sent to Auston! Filed as ' +
+            '<a href="' + r.url + '" target="_blank" rel="noopener" ' +
+              'style="color:var(--accent);text-decoration:underline">issue #' + r.number + '</a>.' +
+          '</div>';
+      } else {
+        var note = r.error
+          ? 'Auto-post failed (' + esc(r.error) + ') — opened GitHub so you can post manually.'
+          : 'Saved locally. We opened a pre-filled GitHub page so Auston can see it.';
+        status.innerHTML =
+          '<div class="fb-correct" style="line-height:1.5">' +
+            '&#x2705; ' + note + '<br>' +
+            '<a href="' + r.url + '" target="_blank" rel="noopener" ' +
+              'style="color:var(--accent);text-decoration:underline;font-size:0.9rem">Open the GitHub page again</a>' +
+          '</div>';
+      }
+      self.renderHistory();
+    });
   },
 
   renderHistory: function() {

--- a/worker/README.md
+++ b/worker/README.md
@@ -1,0 +1,71 @@
+# Feedback-to-GitHub Worker
+
+Tiny Cloudflare Worker that takes a JSON feedback/error payload from the
+static study app and files it as a GitHub issue using a server-side token.
+The static page never sees the token.
+
+## Why
+
+GitHub Pages is static-only and the GitHub Issues API rejects unauthenticated
+POSTs. To auto-post feedback (no click-through), we need a hosted endpoint
+that holds a token. Cloudflare Workers' free tier (100k requests/day) is
+plenty for this and doesn't require a credit card.
+
+## One-time setup
+
+1. **Create a fine-grained Personal Access Token**
+   - https://github.com/settings/personal-access-tokens/new
+   - "Only select repositories" → pick `Satuno86/conjugate-study-hub`
+   - Repository permissions → **Issues: Read and write**
+   - Everything else: No access
+   - Copy the token (you'll only see it once)
+
+2. **Install wrangler** (Cloudflare's CLI)
+   ```sh
+   npm install -g wrangler
+   wrangler login
+   ```
+
+3. **Configure and deploy**
+   ```sh
+   cd worker
+   wrangler secret put GITHUB_TOKEN
+   # paste the PAT when prompted
+   wrangler deploy
+   ```
+
+   wrangler will print the deploy URL, e.g.
+   `https://conjugate-feedback.<your-subdomain>.workers.dev`.
+
+4. **Wire it into the app**
+   - Open `index.html`, find `BUG.FEEDBACK_ENDPOINT`, and paste the URL.
+   - Commit + push.
+
+## What it does
+
+- Accepts `POST` with JSON `{ title, body, labels }`.
+- Validates basic shape (size limits, required fields, honeypot).
+- Calls `POST /repos/{owner}/{repo}/issues` with the stored token.
+- Returns `{ url, number }` on success or `{ error }` on failure.
+- Sends CORS headers so the static page can call it from
+  `https://satuno86.github.io` (or `localhost` during dev).
+
+## What it does NOT do
+
+- No persistence. No rate limiting beyond Cloudflare's defaults.
+- No spam/abuse detection beyond the honeypot field.
+- No DMs / no comment posting. Issues only.
+
+If abuse becomes a problem, add a Cloudflare WAF rule rate-limiting POSTs
+to this worker by IP, or wire in Turnstile.
+
+## Local testing
+
+```sh
+wrangler dev
+# Worker runs at http://localhost:8787
+```
+
+Point the static page at it temporarily by setting
+`BUG.FEEDBACK_ENDPOINT = 'http://localhost:8787'` in DevTools, or edit
+`index.html` locally.

--- a/worker/feedback-issue.js
+++ b/worker/feedback-issue.js
@@ -1,0 +1,114 @@
+// Cloudflare Worker: accepts feedback/error payloads from the static app
+// and files them as GitHub issues using a server-side token.
+//
+// Configure via environment variables (wrangler secrets):
+//   GITHUB_TOKEN  – fine-grained PAT scoped to the target repo, "Issues: write"
+//   GH_OWNER      – repo owner (default: Satuno86)
+//   GH_REPO       – repo name (default: conjugate-study-hub)
+//   ALLOWED_ORIGINS – comma-separated list of allowed Origin headers
+//                     (default: the GitHub Pages origin)
+
+const DEFAULT_ALLOWED = [
+  'https://satuno86.github.io',
+  'http://localhost:3000',
+  'http://localhost:8765',
+  'http://127.0.0.1:8765',
+];
+
+function allowedSet(env) {
+  const raw = (env.ALLOWED_ORIGINS || '').trim();
+  if (!raw) return new Set(DEFAULT_ALLOWED);
+  return new Set(raw.split(',').map((s) => s.trim()).filter(Boolean));
+}
+
+function corsHeaders(req, env) {
+  const origin = req.headers.get('Origin') || '';
+  const allowed = allowedSet(env);
+  const allow = allowed.has(origin) ? origin : [...allowed][0];
+  return {
+    'Access-Control-Allow-Origin': allow,
+    'Access-Control-Allow-Methods': 'POST, OPTIONS',
+    'Access-Control-Allow-Headers': 'Content-Type',
+    'Access-Control-Max-Age': '86400',
+    Vary: 'Origin',
+  };
+}
+
+function json(status, body, headers = {}) {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json', ...headers },
+  });
+}
+
+export default {
+  async fetch(req, env) {
+    const cors = corsHeaders(req, env);
+
+    if (req.method === 'OPTIONS') {
+      return new Response(null, { status: 204, headers: cors });
+    }
+    if (req.method !== 'POST') {
+      return json(405, { error: 'POST only' }, cors);
+    }
+
+    let payload;
+    try {
+      payload = await req.json();
+    } catch (e) {
+      return json(400, { error: 'invalid JSON' }, cors);
+    }
+
+    // Honeypot: silently drop anything filling the fake `website` field.
+    if (payload && payload.website) {
+      return json(200, { ok: true, suppressed: true }, cors);
+    }
+
+    const title = String(payload.title || '').trim();
+    const body = String(payload.body || '').trim();
+    const labelsInput = payload.labels;
+    let labels = [];
+    if (Array.isArray(labelsInput)) {
+      labels = labelsInput.map(String);
+    } else if (typeof labelsInput === 'string' && labelsInput) {
+      labels = labelsInput.split(',');
+    }
+    labels = labels.map((s) => s.trim()).filter(Boolean).slice(0, 8);
+
+    if (!title || title.length > 200) {
+      return json(400, { error: 'title required (1-200 chars)' }, cors);
+    }
+    if (!body || body.length > 30000) {
+      return json(400, { error: 'body required (1-30000 chars)' }, cors);
+    }
+
+    const owner = env.GH_OWNER || 'Satuno86';
+    const repo = env.GH_REPO || 'conjugate-study-hub';
+    if (!env.GITHUB_TOKEN) {
+      return json(500, { error: 'GITHUB_TOKEN not configured on worker' }, cors);
+    }
+
+    const ghRes = await fetch(`https://api.github.com/repos/${owner}/${repo}/issues`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${env.GITHUB_TOKEN}`,
+        Accept: 'application/vnd.github+json',
+        'User-Agent': 'conjugate-study-hub-feedback-worker',
+        'X-GitHub-Api-Version': '2022-11-28',
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ title, body, labels }),
+    });
+
+    if (!ghRes.ok) {
+      const txt = await ghRes.text();
+      return json(ghRes.status, {
+        error: 'GitHub API error',
+        status: ghRes.status,
+        detail: txt.slice(0, 500),
+      }, cors);
+    }
+    const issue = await ghRes.json();
+    return json(200, { url: issue.html_url, number: issue.number }, cors);
+  },
+};

--- a/worker/feedback-issue.js
+++ b/worker/feedback-issue.js
@@ -52,6 +52,14 @@ export default {
       return json(405, { error: 'POST only' }, cors);
     }
 
+    // Enforce the origin allowlist. CORS headers alone only prevent the
+    // browser from reading the response — a third party can still issue a
+    // blind cross-origin POST and abuse the token. Reject here explicitly.
+    const origin = req.headers.get('Origin') || '';
+    if (!allowedSet(env).has(origin)) {
+      return json(403, { error: 'origin not allowed' }, cors);
+    }
+
     let payload;
     try {
       payload = await req.json();

--- a/worker/wrangler.toml
+++ b/worker/wrangler.toml
@@ -1,0 +1,17 @@
+name = "conjugate-feedback"
+main = "feedback-issue.js"
+compatibility_date = "2026-01-01"
+
+# After `wrangler login`:
+#   wrangler secret put GITHUB_TOKEN
+#   wrangler deploy
+#
+# The deploy URL will be something like
+#   https://conjugate-feedback.<your-subdomain>.workers.dev
+# Paste that URL into BUG.FEEDBACK_ENDPOINT in index.html.
+
+[vars]
+GH_OWNER = "Satuno86"
+GH_REPO = "conjugate-study-hub"
+# Override ALLOWED_ORIGINS if you serve the app from a custom domain.
+# ALLOWED_ORIGINS = "https://your-domain.example,https://satuno86.github.io"


### PR DESCRIPTION
## Summary

Two coordinated changes so feedback Anna files actually becomes a GitHub issue — first, surfaceable error reports from anywhere in the app; second, an auto-post pipeline so she never has to click through to github.com.

### Error reporting (UI)

- **New `BUG` helper**: builds pre-filled issue payloads with auto-attached diagnostic context (timestamp, URL, user email, user agent, last 5 captured JS errors).
- **Header 🐛 button** — "Report a problem" — always visible, prompts for a one-line description.
- **Persistent error banner** replacing the fleeting error toast: when `window.onerror` or `unhandledrejection` fires, a red banner appears with **Report** and **Dismiss** buttons and does not auto-dismiss.
- The Survey panel's existing "post on GitHub" link now uses the same helper, so feedback issues get the same diagnostic context.

### Auto-post (backend)

- **Cloudflare Worker** at `worker/feedback-issue.js` that holds a server-side GitHub token and creates issues via `POST /repos/{owner}/{repo}/issues`. CORS scoped to the GitHub Pages origin (and localhost for dev). Honeypot field for spam suppression. `wrangler.toml` + `README.md` with deploy steps.
- **Client wires up `BUG.FEEDBACK_ENDPOINT`** (empty by default → falls back to opening a pre-filled new-issue tab; non-empty → POSTs to the Worker). Survey, prompt, and error-banner all route through `BUG.reportIssue` which tries the Worker first and falls back automatically if it's down or unconfigured.

## Deployment

1. Create a fine-grained GitHub PAT scoped to `Satuno86/conjugate-study-hub` with `Issues: Read and write`.
2. `cd worker && wrangler secret put GITHUB_TOKEN && wrangler deploy`.
3. Paste the deploy URL into `BUG.FEEDBACK_ENDPOINT` in `index.html`, commit, push.

Detailed steps in `worker/README.md`.

## Verified end-to-end (58/58 checks across three audits)

| Audit | Result |
|---|---|
| Login-gate regression (auth flow, XSS, sign-out) | 18/18 |
| Error reporting (BUG helper, banner, survey link, diagnostics) | 21/21 |
| Auto-post (default fallback, success, worker error, payload shape, toast text) | 19/19 |

## Test plan

- [ ] Without configuring the Worker: click the 🐛 button, submit Survey feedback, or trigger a JS error → in every case, a new tab opens to a pre-filled github.com issues/new page. (Fallback path — unchanged from PR-12 baseline.)
- [ ] After deploying the Worker and pasting its URL into `BUG.FEEDBACK_ENDPOINT`: same actions → toast says "Reported! Issue #N filed." and no new tab opens. An actual issue is filed on the repo.
- [ ] Take the Worker offline / break it: same actions → toast says "Auto-post failed (...) — opened GitHub to file manually." and the fallback tab opens.
- [ ] Login gate (PR #9/#10) still works on first visit and reload.
- [ ] No regression on the Playwright spec at `tests/app.spec.js`.

https://claude.ai/code/session_01BoYpAjhx865wfSwt5m6FZ4